### PR TITLE
Fixed bugs in migrations.

### DIFF
--- a/app/helpers/admin/assets_helper.rb
+++ b/app/helpers/admin/assets_helper.rb
@@ -1,4 +1,15 @@
 module Admin::AssetsHelper  
+  def asset_listing(asset)
+    asset_icon(asset) +
+    content_tag(:span, asset.to_s, :class=>'title')
+  end
+  
+  def asset_grid_item(asset)
+    asset_icon(asset, 120) +
+    content_tag(:span, "ID: #{asset.id}", :class => 'id') +
+    content_tag(:span, asset.to_s, :class => 'caption')
+  end
+
   def asset_icon(asset, size=30)
     asset.image? ? square_thumb(asset, size) : text_icon(asset, size)
   end
@@ -40,5 +51,18 @@ module Admin::AssetsHelper
   
   def audio_player(asset)
     %Q{<audio src="#{asset.upload.url}" type="#{asset.upload.mime_type}" controls="controls">}
+  end
+
+  def link_to_remove(asset)
+    link_to 'Remove', remove_admin_asset_path(asset), :class => 'action remove', :title => 'Remove Asset'
+  end
+  
+  def list_view?
+    params[:view] == 'list'
+  end
+  
+  def view_toggle
+    other = list_view? ? 'grid' : 'list'
+    link_to "Switch to #{other} view", admin_assets_path(:view => other)
   end
 end

--- a/app/helpers/admin/assets_helper.rb
+++ b/app/helpers/admin/assets_helper.rb
@@ -1,15 +1,4 @@
-module AssetsHelper  
-  def asset_listing(asset)
-    asset_icon(asset) +
-    content_tag(:span, asset.to_s, :class=>'title')
-  end
-  
-  def asset_grid_item(asset)
-    asset_icon(asset, 120) +
-    content_tag(:span, "ID: #{asset.id}", :class => 'id') +
-    content_tag(:span, asset.to_s, :class => 'caption')
-  end
-  
+module Admin::AssetsHelper  
   def asset_icon(asset, size=30)
     asset.image? ? square_thumb(asset, size) : text_icon(asset, size)
   end
@@ -51,18 +40,5 @@ module AssetsHelper
   
   def audio_player(asset)
     %Q{<audio src="#{asset.upload.url}" type="#{asset.upload.mime_type}" controls="controls">}
-  end
-  
-  def link_to_remove(asset)
-    link_to 'Remove', remove_admin_asset_path(asset), :class => 'action remove', :title => 'Remove Asset'
-  end
-  
-  def list_view?
-    params[:view] == 'list'
-  end
-  
-  def view_toggle
-    other = list_view? ? 'grid' : 'list'
-    link_to "Switch to #{other} view", admin_assets_path(:view => other)
   end
 end

--- a/db/migrate/20110224001246_add_images_table.rb
+++ b/db/migrate/20110224001246_add_images_table.rb
@@ -6,6 +6,6 @@ class AddImagesTable < ActiveRecord::Migration
   end
 
   def self.down
-    drop_table
+    drop_table :images
   end
 end

--- a/db/migrate/20110225210912_add_timestamps_and_locking_to_assets.rb
+++ b/db/migrate/20110225210912_add_timestamps_and_locking_to_assets.rb
@@ -12,8 +12,8 @@ class AddTimestampsAndLockingToAssets < ActiveRecord::Migration
   end
 
   def self.down
+    remove_column :assets, :updated_at
+    remove_column :assets, :created_at
     remove_column :assets, :lock_version
-    add_column :assets, :created_at
-    add_column :assets, :updated_at
   end
 end

--- a/db/migrate/20110320152044_add_position_to_attachments.rb
+++ b/db/migrate/20110320152044_add_position_to_attachments.rb
@@ -1,6 +1,10 @@
 class AddPositionToAttachments < ActiveRecord::Migration
   def self.up
+    rename_column :attachments, :page_id, :parent_id
     add_column :attachments, :position, :integer
+    add_column :attachments, :parent_type, :string
+    Attachment.update_all 'parent_type = "Page"'
+    
     Page.all(:include => :attachments).each do |page|
       page.attachments.each_with_index do |attachment, index|
         attachment.update_attributes :position => index+1
@@ -9,6 +13,9 @@ class AddPositionToAttachments < ActiveRecord::Migration
   end
 
   def self.down
+    warn 'This will delete all Attachments that aren’t attached to pages'
+    remove_column :attachments, :parent_type
     remove_column :attachments, :position
+    rename_column :attachments, :parent_id, :page_id
   end
 end

--- a/db/migrate/20110321005357_make_attachments_polymorphic.rb
+++ b/db/migrate/20110321005357_make_attachments_polymorphic.rb
@@ -1,17 +1,12 @@
 class MakeAttachmentsPolymorphic < ActiveRecord::Migration
   def self.up
-    rename_column :attachments, :page_id, :parent_id
-    add_column :attachments, :parent_type, :string
-    Attachment.update_all 'parent_type = "Page"'
-
     rename_column :attachments, :asset_id, :attachable_id
     add_column :attachments, :attachable_type, :string
     Attachment.update_all 'attachable_type = "Asset"'
   end
 
   def self.down
-    warn 'This will delete all Attachments that aren’t attached to pages'
-    remove_column :attachments, :parent_type
-    rename_column :attachments, :parent_id, :page_id
+    remove_column :attachments, :attachable_type
+    rename_column :attachments, :attachable_id, :asset_id
   end
 end


### PR DESCRIPTION
The AddPositionToAttachments migration broke when it executed Page.all(:include => :attachments).each do |page| (I think this was the line). It created a MySQL error because the parent_id didn't exist, yet, but the code assumed it did.

I also edited some self.down methods so we could undo migrations cleanly; there were some errors in those methods, too.
